### PR TITLE
Convert generated methods to macros instead

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: kilt-components
-version: 2.0.4
+version: 2.0.5
 
 authors:
   - Troy Sornson <troy@sornson.io>

--- a/src/components/component.cr
+++ b/src/components/component.cr
@@ -22,20 +22,52 @@ module Kilt::Component
     {% verbatim do %}
     macro finished
       {% for c in Kilt::Component.includers %}
-        def {{c.constant("COMPONENT__NAME").id}}(*args, **kwargs)
-          {{c}}.new(*args, **kwargs).as(Kilt::Component)
+        macro {{c.constant("COMPONENT__NAME").id}}(*args, **kwargs, &block)
+          \{% if block %}
+            \{% if args.size > 0 && kwargs.size > 0 %}
+            {{c}}.new(\{{*args}}, \{{**kwargs}}) { \{{yield}} }.as(Kilt::Component)
+            \{% elsif args.size > 0 %}
+            {{c}}.new(\{{*args}}) { \{{yield}} }.as(Kilt::Component)
+            \{% elsif kwargs.size > 0 %}
+            {{c}}.new(\{{**kwargs}}) { \{{yield}} }.as(Kilt::Component)
+            \{% else %}
+            {{c}}.new \{{yield}}.as(Kilt::Component)
+            \{% end %}
+          \{% else %}
+            \{% if args.size > 0 && kwargs.size > 0 %}
+            {{c}}.new(\{{*args}}, \{{**kwargs}}).as(Kilt::Component)
+            \{% elsif args.size > 0 %}
+            {{c}}.new(\{{*args}}).as(Kilt::Component)
+            \{% elsif kwargs.size > 0 %}
+            {{c}}.new(\{{**kwargs}}).as(Kilt::Component)
+            \{% else %}
+            {{c}}.new.as(Kilt::Component)
+            \{% end %}
+          \{% end %}
         end
 
-        def render_{{c.constant("COMPONENT__NAME").id}}(*args, **kwargs)
-          {{c}}.new(*args, **kwargs).as(Kilt::Component).render
-        end
-
-        def {{c.constant("COMPONENT__NAME").id}}(*args, **kwargs, &block : -> String)
-          {{c}}.new(*args, **kwargs, &block).as(Kilt::Component)
-        end
-
-        def render_{{c.constant("COMPONENT__NAME").id}}(*args, **kwargs, &block : -> String)
-          {{c}}.new(*args, **kwargs, &block).as(Kilt::Component).render
+        macro render_{{c.constant("COMPONENT__NAME").id}}(*args, **kwargs, &block)
+          \{% if block %}
+            \{% if args.size > 0 && kwargs.size > 0 %}
+            {{c}}.new(\{{*args}}, \{{**kwargs}}) { \{{yield}} }.as(Kilt::Component).render
+            \{% elsif args.size > 0 %}
+            {{c}}.new(\{{*args}}) { \{{yield}} }.as(Kilt::Component).render
+            \{% elsif kwargs.size > 0 %}
+            {{c}}.new(\{{**kwargs}}) { \{{yield}} }.as(Kilt::Component).render
+            \{% else %}
+            {{c}}.new { \{{yield}} }.as(Kilt::Component).render
+            \{% end %}
+          \{% else %}
+            \{% if args.size > 0 && kwargs.size > 0 %}
+            {{c}}.new(\{{*args}}, \{{**kwargs}}).as(Kilt::Component).render
+            \{% elsif args.size > 0 %}
+            {{c}}.new(\{{*args}}).as(Kilt::Component).render
+            \{% elsif kwargs.size > 0 %}
+            {{c}}.new(\{{**kwargs}}).as(Kilt::Component).render
+            \{% else %}
+            {{c}}.new.as(Kilt::Component).render
+            \{% end %}
+          \{% end %}
         end
       {% end %}
       {% debug if flag?(:DEBUG) %}


### PR DESCRIPTION
All components can generate other components through convenience methods of `<namespace>_<component_name>(args)`, or immediately call their render method via the `render_<namespace>_<component_name>(args)`. There were two problems that came up from using `def`s for these convenience methods:

1. Calling the constructor of components that took a mix of required positional arguments and named arguments would throw an error that one of the positional arguments wasn't correct.
2. When compiling where there's a compiler error in one of your components that's constructed through one of these convenience methods, and using the `--error-trace` flag, you'd inevitably be greeted with a wall of text listing out every generated method, even if the error only exists in a single line.

Converting these `def`s to macros resolves both of these problems.